### PR TITLE
Bugfix/respect ipv6 and env in healthbind

### DIFF
--- a/goircd.go
+++ b/goircd.go
@@ -207,13 +207,10 @@ func Run() {
 }
 
 func health_endpoint() {
-	var (
-		health_bind = "0.0.0.0:8086"
-	)
 	health := healthchecking.NewHandler()
 	health.AddLivenessCheck("goroutine-threshold", healthchecking.GoroutineCountCheck(100))
-	log.Printf("Healthcheck listening on http://%s", health_bind)
-	http.ListenAndServe(health_bind, health)
+	log.Printf("Healthcheck listening on http://%s", *healtbind)
+	http.ListenAndServe(*healtbind, health)
 }
 
 func prom_export() {

--- a/goircd.go
+++ b/goircd.go
@@ -39,7 +39,6 @@ import (
 
 const (
 	PROXY_TIMEOUT   = 5
-	HEALTCHECK_PORT = 8080
 )
 
 var (

--- a/goircd.go
+++ b/goircd.go
@@ -57,6 +57,7 @@ var (
 	metrics      = flag.Bool("metrics", false, "Enable metrics export")
 	verbose      = flag.Bool("v", false, "Enable verbose logging.")
 	healtcheck   = flag.Bool("healthcheck", false, "Enable healthcheck endpoint.")
+	healtbind    = flag.String("healthbind", "[::]:8086", "Healthcheck bind address and port.")
 
 	clients_tls_total = prometheus.NewCounter(
 		prometheus.CounterOpts{


### PR DESCRIPTION
Use provided argument or fall-back for health-bind.

The following arguments may used to specifiy health-check behavior:
* `-healthcheck` : Enable healthcheck (default: `false`)
* `-healthbind=[::1]:8086` : Override Healthcheck bind-address (default: `[::]:8086`

You may use the environment variables `HEALTHCHECK` and `HEALTHBIND` instead of commandline arguments.